### PR TITLE
Fix for issue #1: Import into Django namespace

### DIFF
--- a/docs/widgets.rst
+++ b/docs/widgets.rst
@@ -6,8 +6,8 @@ Default widgets for form fields
 
 The first column represents the name of a django.forms field. FloppyForms aims
 to implement all the Django fields with the same class name, in the
-``floppyforms`` namespace. Some widgets are missing but you can safely use the
-widgets from ``django.forms`` if you need them.
+``floppyforms`` namespace. Some widgets and fields are missing but the appropriate
+fields and widgets have been imported from the ``django.forms`` namespace.
 
 ======================== =================
 Fields                   Widgets
@@ -39,11 +39,35 @@ ModelChoiceField         Not implemented
 ModelMultipleChoiceField Not implemented
 ======================== =================
 
+The following fields have not yet been implemented.
+
+========================
+Fields Not Implemented
+========================
+TypedChoiceField
+FilePathField
+IPAddressField
+TypedMultipleChoiceField
+NullBooleanField
+RegexField
+SlugField
+ComboField
+MultiValueField
+SplitDateTimeField
+ModelChoiceField
+ModelMultipleChoiceField
+========================
+
+
 .. note:: ClearableFileInput
 
     The ``ClearableFileInput`` widget has been added in Django 1.3. If you use
     django-floppyforms with Django 1.2, the ClearableFileInput will behave
     just like a traditional FileInput.
+
+    The ``TypedMultipleChoiceField`` has also been added in Django 1.3 and is
+    imported into the namespace if it is available.
+
 
 Other (HTML5) widgets
 ---------------------

--- a/floppyforms/__init__.py
+++ b/floppyforms/__init__.py
@@ -1,3 +1,24 @@
 from django.forms import Form, ModelForm
+
+# Import Django Fields not implemented in floppyforms yet
+from django.forms import (TypedChoiceField, FilePathField, IPAddressField,
+                          NullBooleanField, RegexField,
+                          SlugField, ComboField, MultiValueField, SplitDateTimeField,
+                          ModelChoiceField, ModelMultipleChoiceField)
+
+# TypedMultipleChoiceField was added in Django 1.3. Import it if available.
+try:
+    from django.forms import TypedMultipleChoiceField
+except ImportError:
+    "ignored"
+
+# Import Django Widgets not implemented yet
+from django.forms import (PasswordInput, MultipleHiddenInput, Textarea,
+                          NullBooleanSelect, RadioSelect, CheckboxSelectMultiple,
+                          MultiWidget, SplitDateTimeWidget)
+
+# Import SelectDateWidget from extras
+from django.forms.extras import SelectDateWidget
+
 from floppyforms.fields import *
 from floppyforms.widgets import *


### PR DESCRIPTION
This seems to work; give it a shot.

I pulled in the SelectDateWidget into the normal namespace even though it is under the 'extras' namespace in Django. That was done a while back in Django to try to divide the widgets into common/uncommon widgets and save loading time but I don't think it ever really caught on.

An [issue was opened](http://code.djangoproject.com/ticket/4090) a few years ago to move it in but it was voted down. Were effectively doing that here but I'm not sure I think it's that big an issue.
