### PR TITLE
Values not getting passed through when they're false in a boolean context

### DIFF
--- a/floppyforms/widgets.py
+++ b/floppyforms/widgets.py
@@ -36,7 +36,7 @@ class Input(forms.TextInput):
         }
         context.update(extra_context)
 
-        if value:
+        if not value is None:
             context['value'] = value
 
         context.update(self.get_context_data())
@@ -232,12 +232,12 @@ class NullBooleanSelect(forms.NullBooleanSelect, Select):
 
 
 class SelectMultiple(forms.SelectMultiple, Select):
-
+    
     def get_context_data(self):
         ctx = super(SelectMultiple, self).get_context_data()
         ctx['multiple'] = True
         return ctx
-
+        
     def render(self, name, value, attrs=None, choices=()):
         return Select.render(self, name, value, attrs=attrs, choices=choices)
 


### PR DESCRIPTION
When the context is being populated in Input's get_context function the following code is run

```
if value:
    context['value'] = value
```

That prevents None from getting through (which is good), but it also prevents 0 getting through (this is bad). It also prevents False from going through (I am unsure as to whether that is good or bad). The use case that this messed up for me was a Select field defined as follows

```
Select(choices=([(hour % 12, hour) for hour in range(1,13)]))
```

Which when rendered with a value of 0 (regression testing via working just after midnight) resulted in no option being marked selected. When using django.forms.Select, I got the correct behavior.
