### PR TITLE
Select Multiple broken by latest release

### DIFF
--- a/floppyforms/tests/__init__.py
+++ b/floppyforms/tests/__init__.py
@@ -330,6 +330,26 @@ class WidgetRenderingTest(TestCase):
         self.assertTrue('"fr" selected' in rendered, rendered)
         self.assertTrue('"en" selected' in rendered, rendered)
 
+
+    def test_select_multiple_values(self):
+        """<select multiple>"""
+        CHOICES = (
+            ('1', 'English'),
+            ('12', 'Deutsch'),
+            ('123', 'Francais'),
+        )
+
+        class MultiForm(forms.Form):
+            multi = forms.MultipleChoiceField(choices=CHOICES)
+
+        rendered = MultiForm().as_p()
+        self.assertTrue('multiple' in rendered, rendered)
+
+        rendered = MultiForm(data={'multi': ['123']}).as_p()
+        self.assertFalse('"1" selected' in rendered, rendered)
+        self.assertFalse('"12" selected' in rendered, rendered)
+        self.assertTrue('"123" selected' in rendered, rendered)
+
     def test_cb_multiple(self):
         """CheckboxSelectMultiple"""
         CHOICES = (


### PR DESCRIPTION
Coercing all values into strings breaks select multiple, which relies on value being an array. It slipped through the test suite since none of the values are substrings of each other.

In a case like the following:
    choices = (('1', 'foo'), ('12', 'bar'), ('123', 'baz'))
    value = ['123']
value is coerced into the string `"['123']"` which results in logic errors since `'1' in "['123']"` is True and `'1' in ['123']` is False

Note: this pull request doesn't solve the problem, it just provides a test case clearly illustrating it.
