### PR TITLE
support for trunk django

### DIFF
--- a/floppyforms/__init__.py
+++ b/floppyforms/__init__.py
@@ -1,9 +1,11 @@
 from django.forms import (Form, ModelForm, BaseModelForm, model_to_dict,
                           fields_for_model, save_instance, ValidationError,
-                          DEFAULT_DATE_INPUT_FORMATS,
-                          DEFAULT_TIME_INPUT_FORMATS,
-                          DEFAULT_DATETIME_INPUT_FORMATS,
                           Media, MediaDefiningClass)
+
+from django.contrib.localflavor.generic.forms import (
+                          DEFAULT_DATE_INPUT_FORMATS,
+                          DEFAULT_DATETIME_INPUT_FORMATS,
+)
 
 # Import SelectDateWidget from extras
 from django.forms.extras import SelectDateWidget


### PR DESCRIPTION
in django trunk there are no DEFAULT_TIME_INPUT_FORMATS, it is in localflavor now
