### PR TITLE
Widgets clutter template context

### DIFF
--- a/floppyforms/widgets.py
+++ b/floppyforms/widgets.py
@@ -86,8 +86,11 @@ class Input(Widget):
 
         if self.context_instance is None:
             return context
-        self.context_instance.update(context)
-        return self.context_instance
+        # update() does a push, which needs to be poped somewhere outside
+        # ...so we work with a copy (yay, fun!)
+        context_instance = copy(self.context_instance)
+        context_instance.update(context)
+        return context_instance
 
     def render(self, name, value, attrs=None, **kwargs):
         context = self.get_context(name, value, attrs=attrs or {}, **kwargs)


### PR DESCRIPTION
Widgets will use the context_instance of the template (provided by the template tag) if possible. Because widgets also add more data to this context (using context.update()) they do an implicit push on the template context. All template tags normally do a pop afterwards to restore order. As the widget has no means to know about using the template context outside of get_context() the pop() is never done (and probably is not easy to implement). I fixed this by using a copy of the original context(_instance) to render the widget templates. Not sure if this affects other code parts, but this actually did cost some time to debug. Changing the base Widget seems to work here for now, hope no other incarnations of this bug will occur.
