### PR TITLE
floppyforms should import FILE_INPUT_CONTRADICTION instead of defining a new object

### DIFF
--- a/floppyforms/widgets.py
+++ b/floppyforms/widgets.py
@@ -3,6 +3,7 @@ import re
 import datetime
 
 from django import forms
+from django.forms.widgets import FILE_INPUT_CONTRADICTION
 from django.conf import settings
 from django.template import loader
 from django.utils.datastructures import MultiValueDict, MergeDict
@@ -181,9 +182,6 @@ class FileInput(Input):
         if data is None:
             return False
         return True
-
-
-FILE_INPUT_CONTRADICTION = object()
 
 
 class ClearableFileInput(FileInput):


### PR DESCRIPTION
Currently you cannot just use the ClearableFileInput widget in combination with the standard Django FileField as FILE_INPUT_CONTRADICTION is redefined in widgets.py. This can be fixed easily by importing FILE_INPUT_CONTRADICTION from django.forms.widgets, so both implementations share the same marker-object.
