### PR TITLE
Django 1.5 removes localflavor

### DIFF
--- a/floppyforms/__init__.py
+++ b/floppyforms/__init__.py
@@ -3,16 +3,6 @@ from django.forms import (BaseModelForm, model_to_dict, fields_for_model,
                           save_instance, ValidationError, Media,
                           MediaDefiningClass)
 
-try:
-    from django.contrib.localflavor.generic.forms import (
-        DEFAULT_DATE_INPUT_FORMATS,
-        DEFAULT_DATETIME_INPUT_FORMATS,
-    )
-except ImportError:
-    from django.conf import settings
-    DEFAULT_DATE_INPUT_FORMATS = settings.DATE_INPUT_FORMATS
-    DEFAULT_DATETIME_INPUT_FORMATS = settings.DATETIME_INPUT_FORMATS
-
 from .fields import *
 from .forms import *
 from .models import *


### PR DESCRIPTION
I've updated urls.py to pull the default date/time formats from the equivalent settings if they can't be imported from localflavor.
