### PR TITLE
Modified unicode string literal for Python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def find_version(*file_paths):
 setup(
     name='django-floppyforms',
     version=find_version('floppyforms', '__init__.py'),
-    author=u'Bruno Renié',
+    author='Bruno Renié',
     author_email='bruno@renie.fr',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Modified unicode string literal for Python 3 compatibility in 'author'. Installation using "python3 setup.py install"  doesn't fail anymore.
