### PR TITLE
Added *.pyc and __pycache__ to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 docs/_build
 .coverage
 .tox/
+*.pyc
+__pycache__


### PR DESCRIPTION
`__pycache__` directories are (I believe) generated during tox runs of pypy tests. pyc files are always generated when the code compiles. I'm not sure if they've been left out for philosophical reasons, but since they should never be included in a commit, it seems like it wouldn't hurt to include them.
