### PR TITLE
Allow to change the default template name for each widget

### DIFF
--- a/floppyforms/forms.py
+++ b/floppyforms/forms.py
@@ -2,9 +2,41 @@ from django import forms, template
 from django.utils.encoding import python_2_unicode_compatible
 
 from .templatetags.floppyforms import FormNode
+from .widgets import Widget, MultiWidget, SelectDateWidget
 
 
 __all__ = ('BaseForm', 'Form',)
+
+
+class BoundField(forms.forms.BoundField):
+    def as_widget(self, widget=None, attrs=None, only_initial=False, **kwargs):
+        """
+        Renders the field by rendering the passed widget, adding any HTML
+        attributes passed as attrs.  If no widget is specified, then the
+        field's default widget will be used.
+        """
+        if not widget:
+            widget = self.field.widget
+
+        if self.field.localize:
+            widget.is_localized = True
+
+        attrs = attrs or {}
+        auto_id = self.auto_id
+        if auto_id and 'id' not in attrs and 'id' not in widget.attrs:
+            if not only_initial:
+                attrs['id'] = auto_id
+            else:
+                attrs['id'] = self.html_initial_id
+
+        if not only_initial:
+            name = self.html_name
+        else:
+            name = self.html_initial_name
+        if isinstance( widget, (Widget, MultiWidget, SelectDateWidget,)  ):
+            return widget.render(name, self.value(), attrs=attrs, **kwargs)
+        else:
+            return widget.render(name, self.value(), attrs=attrs, )
 
 
 @python_2_unicode_compatible
@@ -36,6 +68,14 @@ class LayoutRenderer(object):
 
     def as_table(self):
         return self._render_as('floppyforms/layouts/table.html')
+
+    def __getitem__(self, name):
+        "Returns a BoundField with the given name."
+        try:
+            field = self.fields[name]
+        except KeyError:
+            raise KeyError('Key %r not found in Form' % name)
+        return BoundField(self, field, name)
 
 
 class BaseForm(LayoutRenderer, forms.BaseForm):

--- a/floppyforms/local_settings.py
+++ b/floppyforms/local_settings.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from django.conf import settings
+
+__all__ = ('DEFAULT_WIDGET_TEMPLATES', )
+
+
+DEFAULT_WIDGET_TEMPLATES = {
+    'floppyforms.widgets.Input' : 'floppyforms/input.html',
+#     'floppyforms.widgets.TextInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.PasswordInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.HiddenInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.MultipleHiddenInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.SearchInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.RangeInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.ColorInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.EmailInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.URLInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.PhoneNumberInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.NumberInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.IPAddressInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.FileInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.DateInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.DateTimeInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.TimeInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.CheckboxInput' : 'floppyforms/input.html',
+#     'floppyforms.widgets.SlugInput' : 'floppyforms/input.html',
+    'floppyforms.widgets.ClearableFileInput' : 'floppyforms/clearable_input.html',
+    'floppyforms.widgets.Textarea' : 'floppyforms/textarea.html',
+    'floppyforms.widgets.Select' : 'floppyforms/select.html',
+#     'floppyforms.widgets.NullBooleanSelect' : 'floppyforms/select.html',
+#     'floppyforms.widgets.SelectMultiple' : 'floppyforms/select.html',
+    'floppyforms.widgets.RadioSelect' : 'floppyforms/radio.html',
+    'floppyforms.widgets.CheckboxSelectMultiple' : 'floppyforms/checkbox_select.html',
+    'floppyforms.widgets.SelectDateWidget' : 'floppyforms/select_date.html',
+}
+DEFAULT_WIDGET_TEMPLATES.update(getattr(settings, 'FLOPPYFORMS_DEFAULT_WIDGET_TEMPLATES', {}))

--- a/floppyforms/utils.py
+++ b/floppyforms/utils.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from django.forms.widgets import Widget
+
+from . import local_settings
+
+__all__ = ('get_template_by_class', )
+
+
+def get_template_by_class(widget_or_class):
+    if isinstance(widget_or_class, Widget):
+        widget_or_class = widget_or_class.__class__
+    key = "%s.%s" % (widget_or_class.__module__, widget_or_class.__name__, )
+    print widget_or_class, key, local_settings.DEFAULT_WIDGET_TEMPLATES.has_key(key), '++++++++++++++++'
+    template_name = local_settings.DEFAULT_WIDGET_TEMPLATES.get(key, None)
+    if template_name is None:
+        for base_class in widget_or_class.__bases__:
+            if issubclass(base_class, Widget) and base_class <> Widget:
+                template_name = get_template_by_class(base_class)
+                if template_name is not None:
+                    break
+    
+    return template_name


### PR DESCRIPTION
1. Now the default template name for each widget could be changed thru FLOPPYFORMS_DEFAULT_WIDGET_TEMPLATES
2. Now the floppyforms.forms.Form is using an extended BoundField class to pass the additional context to as_widget() method during rendering
