### PR TITLE
DateInput widget  render hardcoded "%Y-%m-%d" format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.3.0 (not released)
 ~~~~~~~~~~~~~~~~~~~~
 
+* DateInput widget renders hardcoded "%Y-%m-%d" format
+
 * Adding ``supports_microseconds`` attribute to all relevant widget classes.
   Thanks to Stephen Burrows for the patch.
 

--- a/docs/widgets-reference.rst
+++ b/docs/widgets-reference.rst
@@ -176,6 +176,10 @@ For each widgets, the default class attributes.
 
         ``date``
 
+    A widget that renders as ``<input type="date" value="...">``. Value
+    is rendered in ISO-8601 format regardless of localization settings.
+
+
 .. class:: DateTimeInput
 
     .. attribute:: DateTimeInput.template_name

--- a/floppyforms/widgets.py
+++ b/floppyforms/widgets.py
@@ -260,12 +260,7 @@ class DateInput(Input):
 
     def __init__(self, attrs=None, format=None):
         super(DateInput, self).__init__(attrs)
-        if format:
-            self.format = format
-            self.manual_format = True
-        else:
-            self.format = formats.get_format('DATE_INPUT_FORMATS')[0]
-            self.manual_format = False
+        self.format = '%Y-%m-%d'
 
     def _format_value(self, value):
         if hasattr(value, 'strftime'):

--- a/tests/widgets.py
+++ b/tests/widgets.py
@@ -245,6 +245,20 @@ class WidgetRenderingTest(TestCase):
         </p>
         """)
 
+    @override_settings(LANGUAGE_CODE='sl', USE_I18n=True)
+    def test_date_with_locale(self):
+        """<input type="date">"""
+        class DateForm(forms.Form):
+            date = forms.DateField(initial=datetime.date(2014, 1, 31))
+
+        rendered = DateForm().as_p()
+        self.assertHTMLEqual(rendered, """
+        <p>
+            <label for="id_date">Date:</label>
+            <input type="date" value="2014-01-31" name="date" id="id_date" required>
+        </p>
+        """)
+
     def test_search(self):
         """<input type="search">"""
         class SearchForm(forms.Form):


### PR DESCRIPTION
FIX: #115 - Implementation of DateInput widget should render hardcoded "%Y-%m-%d" format
