### PR TITLE
Use tox-1.8 style config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 language: python
 python: 2.7
 env:
-  - TOXENV=py26-1.4
-  - TOXENV=py26-1.5
-  - TOXENV=py26-1.6
-  - TOXENV=py27-1.4
-  - TOXENV=py27-1.5
-  - TOXENV=py27-1.6
-  - TOXENV=py27-1.7
-  - TOXENV=py33-1.5
-  - TOXENV=py33-1.6
-  - TOXENV=py33-1.7
-  - TOXENV=pypy-1.4
-  - TOXENV=pypy-1.5
-  - TOXENV=pypy-1.6
-  - TOXENV=pypy-1.7
+  - TOXENV=py26-14
+  - TOXENV=py26-15
+  - TOXENV=py26-16
+  - TOXENV=py27-14
+  - TOXENV=py27-15
+  - TOXENV=py27-16
+  - TOXENV=py27-17
+  - TOXENV=py33-15
+  - TOXENV=py33-16
+  - TOXENV=py33-17
+  - TOXENV=pypy-14
+  - TOXENV=pypy-15
+  - TOXENV=pypy-16
+  - TOXENV=pypy-17
   - TOXENV=docs
   - TOXENV=flake8
 before_install:
@@ -23,7 +23,7 @@ before_install:
 install:
   - pip install tox
 script:
-  - tox -e $TOXENV
+  - tox
 notifications:
   irc:
     channels:

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,19 @@
 [tox]
+minversion = 1.8
 envlist =
     docs,
     flake8,
-    py26-1.4, py26-1.5, py26-1.6,
-    py27-1.4, py27-1.5, py27-1.6, py27-1.7,
-              py33-1.5, py33-1.6, py33-1.7,
-    pypy-1.4, pypy-1.5, pypy-1.6, pypy-1.7
+    py26-1{4,5,6},
+    py{27,py}-1{4,5,6,7},
+    py33-1{5,6,7}
 
 [testenv]
+deps =
+    14: Django >= 1.4, < 1.5
+    15: Django >= 1.5, < 1.6
+    16: Django >= 1.6, < 1.7
+    17: Django >= 1.7, < 1.8
+    -r{toxinidir}/requirements/tests.txt
 commands = python runtests.py
 
 [testenv:docs]
@@ -21,87 +27,3 @@ commands =
 deps =
     flake8
 commands = flake8 floppyforms
-
-[testenv:py26-1.4]
-basepython = python2.6
-deps =
-    Django >= 1.4, < 1.4.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:py26-1.5]
-basepython = python2.6
-deps =
-    Django >= 1.5, < 1.5.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:py26-1.6]
-basepython = python2.6
-deps =
-    Django >= 1.6, < 1.6.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:py27-1.4]
-basepython = python2.7
-deps =
-    Django >= 1.4, < 1.4.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:py27-1.5]
-basepython = python2.7
-deps =
-    Django >= 1.5, < 1.5.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:py27-1.6]
-basepython = python2.7
-deps =
-    Django >= 1.6, < 1.6.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:py27-1.7]
-basepython = python2.7
-deps =
-    https://github.com/django/django/archive/stable/1.7.x.zip#egg=Django
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:py33-1.5]
-basepython = python3.3
-deps =
-    Django >= 1.5, < 1.5.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:py33-1.6]
-basepython = python3.3
-deps =
-    Django >= 1.6, < 1.6.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:py33-1.7]
-basepython = python3.3
-deps =
-    https://github.com/django/django/archive/stable/1.7.x.zip#egg=Django
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:pypy-1.4]
-basepython = pypy
-deps =
-    Django >= 1.4, < 1.4.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:pypy-1.5]
-basepython = pypy
-deps =
-    Django >= 1.5, < 1.5.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:pypy-1.6]
-basepython = pypy
-deps =
-    Django >= 1.6, < 1.6.99
-    -r{toxinidir}/requirements/tests.txt
-
-[testenv:pypy-1.7]
-basepython = pypy
-deps =
-    https://github.com/django/django/archive/stable/1.7.x.zip#egg=Django
-    -r{toxinidir}/requirements/tests.txt


### PR DESCRIPTION
Rewrote `tox.ini` to use tox-1.8 config parametrization. Dots don't work in envnames for some reason so I removed them.

You can now easily add testing on python 3.4 and pypy3 if you wish. Just change `py33` to `py{33,34,py3}` in envlist.
