### PR TITLE
fetch for the issue 189. disable gis feature on settings.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,15 @@ Bugs
 Really? Oh well... Please Report. Or better, fix :) We are happy to help you
 through the process of fixing and testing a bug. Just get in touch.
 
+Disable floppyforms.gif
+-----------------------
+Add option to your `settings.py` on the below
+
+```
+FLOPPY_FORMS_USE_GIS = False
+```
+
+
 Development
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Bugs
 Really? Oh well... Please Report. Or better, fix :) We are happy to help you
 through the process of fixing and testing a bug. Just get in touch.
 
-Disable floppyforms.gif
+Disable django gis
 -----------------------
 Add option to your `settings.py` on the below
 

--- a/floppyforms/__init__.py
+++ b/floppyforms/__init__.py
@@ -2,22 +2,30 @@
 from django.forms import (BaseModelForm, model_to_dict, fields_for_model,
                           ValidationError, Media, MediaDefiningClass)
 
+from django.conf import settings
+
+
 from .fields import *
 from .forms import *
 from .models import *
 from .widgets import *
 
-try:
-    # Django < 1.9
-    from django.forms import save_instance
-except ImportError:
-    pass
+is_use_gis = getattr(settings, 'FLOPPY_FORMS_USE_GIS', True)
 
-try:
-    from . import gis
-except Exception:
-    import warnings
-    warnings.warn(
-        "Unable to import floppyforms.gis, geometry widgets not available")
+if is_use_gis:
+    try:
+        # Django < 1.9
+        from django.forms import save_instance
+    except ImportError:
+        pass
+
+    try:
+        from . import gis
+    except Exception:
+        import warnings
+
+        warnings.warn(
+            "Unable to import floppyforms.gis, geometry widgets not available")
+
 
 __version__ = '1.7.1.dev1'


### PR DESCRIPTION
https://github.com/gregmuellegger/django-floppyforms/issues/189

If don't want to use django's gis feature. 
Can disable to add `FLOPPY_FORMS_USE_GIS = False` option. 
It's simple fetch. 