### PR TITLE
use https for OpenStreetMap links

### DIFF
--- a/floppyforms/gis/widgets.py
+++ b/floppyforms/gis/widgets.py
@@ -165,7 +165,7 @@ class BaseOsmWidget(BaseGeometryWidget):
     class Media:
         js = (
             'floppyforms/openlayers/OpenLayers.js',
-            'http://www.openstreetmap.org/openlayers/OpenStreetMap.js',
+            'https://www.openstreetmap.org/openlayers/OpenStreetMap.js',
             'floppyforms/js/MapWidget.js',
         )
 


### PR DESCRIPTION
For websites with Strict-Transport-Security header set, they won't load http content. Changing to https solves this