### PR TITLE
Use HTTPS for OpenStreetMap links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,12 @@ Changelog
 * `#176`_: Fix HTML validation for hidden textarea used with GIS widgets.
 * `#191`_: Support for Django 1.10. Thanks to MrJmad for the patch.
 * `#194`_: Remove official support for Python 2.6 and Python 3.2.
+* `#204`_: Use HTTPS for OpenStreetMap links. Thanks to dryice for the patch.
 
 .. _#176: https://github.com/gregmuellegger/django-floppyforms/issues/176
 .. _#191: https://github.com/gregmuellegger/django-floppyforms/pull/191
 .. _#194: https://github.com/gregmuellegger/django-floppyforms/pull/194
+.. _#204: https://github.com/jazzband/django-floppyforms/pull/204
 
 1.7.0
 ~~~~~

--- a/floppyforms/gis/widgets.py
+++ b/floppyforms/gis/widgets.py
@@ -162,7 +162,7 @@ class BaseOsmWidget(BaseGeometryWidget):
     class Media:
         js = (
             'floppyforms/openlayers/OpenLayers.js',
-            'http://www.openstreetmap.org/openlayers/OpenStreetMap.js',
+            'https://www.openstreetmap.org/openlayers/OpenStreetMap.js',
             'floppyforms/js/MapWidget.js',
         )
 


### PR DESCRIPTION
This is just #204 with an updated master. Thanks to @dryice for the original patch!