### PR TITLE
Various cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ docs/_build
 .tox/
 *.pyc
 __pycache__
-
+.mypy_cache
 # PyCharm IDE files
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: python
 matrix:
   include:
-  - python: 2.7
-    env: TOXENV=py27-111
   - python: 3.6
-    env: TOXENV=py36-111
-  - python: 3.6
-    env: TOXENV=py36-21
-  - python: 2.7
+    env: TOXENV=py36-22
+  - python: 3.7
+    env: TOXENV=py37-22
+  - python: 3.8
+    env: TOXENV=py38-22
+  - python: 3.7
     env: TOXENV=docs
-  - python: 2.7
+  - python: 3.7
     env: TOXENV=flake8
 before_install:
 - sudo apt-get -q -y update
@@ -38,4 +38,4 @@ deploy:
   on:
     tags: true
     repo: jazzband/django-floppyforms
-    condition: "$TOXENV = py36-21"
+    condition: "$TOXENV = py37-22"

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Get the code::
 
     git clone git@github.com:jazzband/django-floppyforms.git
     cd django-floppyforms
-    virtualenv -p python2 env
+    virtualenv env
     source env/bin/activate
     add2virtualenv .
 
@@ -85,8 +85,14 @@ Install the development requirements::
 
     pip install "tox>=1.8"
 
+
+Currently, you'll need to `install the GeoDjango requirements`_ when running tests.
+
+:: _install the GeoDjango requirements: https://docs.djangoproject.com/en/3.0/ref/contrib/gis/install/geolibs/
+
 Run the tests::
 
-    tox -e py27-16
+    tox
+    tox -e py36-22
 
 You can see all the supported test configurations with ``tox -l``.

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,6 @@
-pip<8.0.0
 argparse
-coverage<4.0
+coverage<6.0
 flake8
 django-discover-runner
 Pillow
+pip <= 21

--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 import argparse
+import logging
+
 import os, sys
+
+log = logging.getLogger(__name__)
 
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
@@ -18,7 +22,13 @@ def runtests(*argv):
     ]
     opts = argparser.parse_args(argv)
 
-    if opts.coverage:
+    is_py38 = sys.version_info.major == 3 and sys.version_info.minor == 8
+    if is_py38:
+        log.warning("Coverage is currently broken in Python 3.8, coveragfe option ignored")
+        use_coverage = False
+    else:
+        use_coverage = opts.coverage
+    if use_coverage:
         from coverage import coverage
         test_coverage = coverage(
             branch=True,
@@ -29,7 +39,7 @@ def runtests(*argv):
     from django.core.management import execute_from_command_line
     execute_from_command_line([sys.argv[0], 'test'] + opts.appname)
 
-    if opts.coverage:
+    if use_coverage:
         test_coverage.stop()
 
         # Report coverage to commandline.

--- a/tests/models.py
+++ b/tests/models.py
@@ -18,7 +18,7 @@ class AllFields(models.Model):
     datetime = models.DateTimeField()
     decimal = models.DecimalField(decimal_places=2, max_digits=4)
     email = models.EmailField()
-    file_path = models.FilePathField()
+    file_path = models.FilePathField(path="tests")
     float_field = models.FloatField()
     integer = models.IntegerField()
     big_integer = models.BigIntegerField()

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,13 @@ minversion = 1.8
 envlist =
     docs,
     flake8,
-    py36-{111,21,22},
-    py37-20
+    py36-22,
+    py37-22,
+    py38-22
 
 [testenv]
 deps =
     111: Django >= 1.11, < 2.0
-    21: Django >= 2.1, < 2.2
     22: Django >= 2.2, < 3.0
     -r{toxinidir}/requirements/tests.txt
 commands = python runtests.py


### PR DESCRIPTION
 - Document needing to install GeoDjango requirements
 - Remove unsupported Django versions from Tox
 - Upgrade some test pinning
 - Special case Python 3.8 coverage issues in runtests.py
 - Fix up FilePathField in tests