### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -88,7 +88,7 @@ extend ``get_context_data()`` which doesn't take any arguments::
 Altering the widget's ``attrs``
 -------------------------------
 
-All widget attibutes except for ``type``, ``name``, ``value`` and ``required``
+All widget attributes except for ``type``, ``name``, ``value`` and ``required``
 are put in the ``attrs`` context variable, which you can extend in
 ``get_context()``:
 

--- a/docs/differences.rst
+++ b/docs/differences.rst
@@ -103,7 +103,7 @@ ModelForms
 
 Prior to version 1.2 of django-floppyforms, you had to take some manual
 efforts to make your modelforms work with floppyforms. This is now done
-seemlesly, but since this was introduced a backwards incompatible change, it
+seamlessly, but since this was introduced a backwards incompatible change, it
 was necessary to provde a deprecation path.
 
 So if you start out new with django-floppyforms just use ``import

--- a/floppyforms/static/floppyforms/js/MapWidget.js
+++ b/floppyforms/static/floppyforms/js/MapWidget.js
@@ -22,7 +22,7 @@ OpenLayers.Util.properFeatures = function(features, geom_type) {
 /**
  * Class: OpenLayers.Format.DjangoWKT
  * Class for reading Well-Known Text, with workarounds to successfully parse
- * geometries and collections as returnes by django.contrib.gis.geos.
+ * geometries and collections as returned by django.contrib.gis.geos.
  *
  * Inherits from:
  *  - <OpenLayers.Format.WKT>


### PR DESCRIPTION
There are small typos in:
- docs/customization.rst
- docs/differences.rst
- floppyforms/static/floppyforms/js/MapWidget.js

Fixes:
- Should read `seamlessly` rather than `seemlesly`.
- Should read `returned` rather than `returnes`.
- Should read `attributes` rather than `attibutes`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md